### PR TITLE
LRAC-7962 Add two new AC test cases, new macros and refactor old ones

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACSegments.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACSegments.macro
@@ -127,7 +127,7 @@ definition {
 	}
 
 	macro includeAnonymous {
-		Click(locator1 = "ACSegments#ANONYMOUS_SWITCH");
+		Check.checkToggleSwitch(locator1 = "ACSegments#ANONYMOUS_SWITCH");
 	}
 
 	macro nameSegment {
@@ -232,9 +232,8 @@ definition {
 	}
 
 	macro viewIncludeAnonymousLabel {
-		AssertTextPresent(
-			locator1 = "ACSegments#ANONYMOUS_LABEL",
-			value1 = "Include Anonymous");
+		AssertElementPresent(
+			locator1 = "ACSegments#ANONYMOUS_LABEL");
 	}
 
 	macro viewSegmentComposition {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACSegments.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACSegments.macro
@@ -68,6 +68,16 @@ definition {
 		Click(locator1 = "ACSegments#CALENDAR_INPUT");
 	}
 
+	macro editFormControlCriterion {
+		var key_Criterion = "${criterionName}";
+
+		var key_option = "${option}";
+
+		Click(locator1 = "ACSegments#FORM_CONTROL_CRITERION");
+
+		Click(locator1 = "ACSegments#FORM_CONTROL_CRITERION_OPTION");
+	}
+
 	macro editSegment {
 		if (!IsTextEqual.isPartialText(locator1 = "ACSegments#SEGMENT_LABEL", value1 = "SEGMENT")) {
 			ACSegments.searchSegment(findSegment = "${searchTerm}");
@@ -174,16 +184,6 @@ definition {
 		Type(
 			locator1 = "ACSegments#OCCURENCE_INPUT",
 			value1 = "${occurenceNumber}");
-	}
-
-	macro editFormControlCriterion {
-		var key_Criterion = "${criterionName}";
-
-		var key_option = "${option}";
-
-		Click(locator1 = "ACSegments#FORM_CONTROL_CRITERION");
-
-		Click(locator1 = "ACSegments#FORM_CONTROL_CRITERION_OPTION");
 	}
 
 	macro viewActivePageCreationModel {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACSegments.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACSegments.macro
@@ -186,23 +186,6 @@ definition {
 			value1 = "${occurenceNumber}");
 	}
 
-	macro viewSegmentMembershipLegendNumbers {
-		AssertTextEquals(
-			key_memberType = "Known Members:",
-			locator1 = "ACSegments#SEGMENT_MEMBERSHIP_LEGEND",
-			value1 = "${knownNumber}");
-
-		AssertTextEquals(
-			key_memberType = "Anonymous Members:",
-			locator1 = "ACSegments#SEGMENT_MEMBERSHIP_LEGEND",
-			value1 = "${anonymousNumber}");
-
-		AssertTextEquals(
-			key_memberType = "Total Members:",
-			locator1 = "ACSegments#SEGMENT_MEMBERSHIP_LEGEND",
-			value1 = "${totalNumber}");
-	}
-
 	macro viewActivePageCreationModel {
 		AssertTextEquals(
 			locator1 = "ACSegments#ACTIVE_PAGE",
@@ -232,8 +215,7 @@ definition {
 	}
 
 	macro viewIncludeAnonymousLabel {
-		AssertElementPresent(
-			locator1 = "ACSegments#ANONYMOUS_LABEL");
+		AssertElementPresent(locator1 = "ACSegments#ANONYMOUS_LABEL");
 	}
 
 	macro viewSegmentComposition {
@@ -265,6 +247,23 @@ definition {
 		AssertTextEquals(
 			locator1 = "ACSegments#SEGMENT_CRITERIA_CRITERIA_VALUE",
 			value1 = "${criteriaValue}");
+	}
+
+	macro viewSegmentMembershipLegendNumbers {
+		AssertTextEquals(
+			key_memberType = "Known Members:",
+			locator1 = "ACSegments#SEGMENT_MEMBERSHIP_LEGEND",
+			value1 = "${knownNumber}");
+
+		AssertTextEquals(
+			key_memberType = "Anonymous Members:",
+			locator1 = "ACSegments#SEGMENT_MEMBERSHIP_LEGEND",
+			value1 = "${anonymousNumber}");
+
+		AssertTextEquals(
+			key_memberType = "Total Members:",
+			locator1 = "ACSegments#SEGMENT_MEMBERSHIP_LEGEND",
+			value1 = "${totalNumber}");
 	}
 
 	macro viewSegmentProfileCards {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACSegments.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACSegments.macro
@@ -186,6 +186,23 @@ definition {
 			value1 = "${occurenceNumber}");
 	}
 
+	macro viewSegmentMembershipLegendNumbers {
+		AssertTextEquals(
+			key_memberType = "Known Members:",
+			locator1 = "ACSegments#SEGMENT_MEMBERSHIP_LEGEND",
+			value1 = "${knownNumber}");
+
+		AssertTextEquals(
+			key_memberType = "Anonymous Members:",
+			locator1 = "ACSegments#SEGMENT_MEMBERSHIP_LEGEND",
+			value1 = "${anonymousNumber}");
+
+		AssertTextEquals(
+			key_memberType = "Total Members:",
+			locator1 = "ACSegments#SEGMENT_MEMBERSHIP_LEGEND",
+			value1 = "${totalNumber}");
+	}
+
 	macro viewActivePageCreationModel {
 		AssertTextEquals(
 			locator1 = "ACSegments#ACTIVE_PAGE",

--- a/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACSegments.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACSegments.macro
@@ -176,6 +176,16 @@ definition {
 			value1 = "${occurenceNumber}");
 	}
 
+	macro editFormControlCriterion {
+		var key_Criterion = "${criterionName}";
+
+		var key_option = "${option}";
+
+		Click(locator1 = "ACSegments#FORM_CONTROL_CRITERION");
+
+		Click(locator1 = "ACSegments#FORM_CONTROL_CRITERION_OPTION");
+	}
+
 	macro viewActivePageCreationModel {
 		AssertTextEquals(
 			locator1 = "ACSegments#ACTIVE_PAGE",

--- a/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACSettings.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACSettings.macro
@@ -46,6 +46,40 @@ definition {
 		}
 	}
 
+	@summary = "Deletes a specific data source \
+	@param dataSourceName the name of the data source you want to delete"
+	macro deleteDataSource {
+		var itemName = "${dataSourceName}";
+
+		if (IsElementNotPresent(locator1 = "ACSettings#EXIT_SETTINGS_BUTTON")) {
+			ACNavigation.goToSettings();
+		}
+
+		ACSettings.goToDataSources();
+
+		Click(locator1 = "ACSettings#SEARCH_BAR");
+
+		Type(
+			locator1 = "ACSettings#SEARCH_BAR",
+			value1 = "${dataSourceName}");
+
+		KeyPress(
+			locator1 = "ACSettings#SEARCH_BAR",
+			value1 = "\ENTER");
+
+		Click(locator1 = "ACSettings#ITEM_ON_LIST");
+
+		Click(locator1 = "ACSettings#GENERIC_DELETE_BUTTON");
+
+		Copy(locator1 = "ACSettings#DELETE_CONFIRMATION_MESSAGE");
+
+		Click(locator1 = "ACSettings#DELETE_CONFIRMATION_INPUT");
+
+		Paste(locator1 = "ACSettings#DELETE_CONFIRMATION_INPUT");
+
+		Click(locator1 = "ACSettings#DELETE_CONFIRMATION_BUTTON");
+	}
+
 	@summary = "Deletes a specific property \
 	@param propertyName the name of the property you want to delete"
 	macro deleteProperty {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACSettings.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACSettings.macro
@@ -18,30 +18,12 @@ definition {
 			value1 = "${keyword}");
 	}
 
-	macro deleteKeywordCheckbox {
-		if (IsVisible(locator1 = "ACSettings#KEYWORD_NAME", value1 = "${keyword}")) {
-			Click(locator1 = "ACSettings#KEYWORD_DELETE_CHECKBOX");
-
-			Click(locator1 = "ACSettings#DELETE_FROM_TOOLBAR");
-
-			Click(locator1 = "ACSettings#CONTINUE_BUTTON");
-		}
-	}
-
-	macro deleteKeywordIcon {
-		if (IsVisible(locator1 = "ACSettings#KEYWORD_NAME", value1 = "${keyword}")) {
-			Click(locator1 = "ACSettings#KEYWORD_DELETE_ICON");
-
-			Click(locator1 = "ACSettings#CONTINUE_BUTTON");
-		}
-	}
-
 	macro deleteAllProperties {
 		if (!(isSet(propertyList))) {
 			var propertyList = "Liferay DXP,Liferay DXP Combined Property";
 		}
 
-		for(var itemName : list "${propertyList}"){
+		for (var itemName : list "${propertyList}") {
 			ACSettings.deleteProperty(propertyName = "${itemName}");
 		}
 	}
@@ -78,6 +60,24 @@ definition {
 		Paste(locator1 = "ACSettings#DELETE_CONFIRMATION_INPUT");
 
 		Click(locator1 = "ACSettings#DELETE_CONFIRMATION_BUTTON");
+	}
+
+	macro deleteKeywordCheckbox {
+		if (IsVisible(locator1 = "ACSettings#KEYWORD_NAME", value1 = "${keyword}")) {
+			Click(locator1 = "ACSettings#KEYWORD_DELETE_CHECKBOX");
+
+			Click(locator1 = "ACSettings#DELETE_FROM_TOOLBAR");
+
+			Click(locator1 = "ACSettings#CONTINUE_BUTTON");
+		}
+	}
+
+	macro deleteKeywordIcon {
+		if (IsVisible(locator1 = "ACSettings#KEYWORD_NAME", value1 = "${keyword}")) {
+			Click(locator1 = "ACSettings#KEYWORD_DELETE_ICON");
+
+			Click(locator1 = "ACSettings#CONTINUE_BUTTON");
+		}
 	}
 
 	@summary = "Deletes a specific property \

--- a/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACSettings.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACSettings.macro
@@ -83,21 +83,25 @@ definition {
 	@summary = "Deletes a specific property \
 	@param propertyName the name of the property you want to delete"
 	macro deleteProperty {
-		ACNavigation.goToSettings();
+		var itemName = "${propertyName}";
+
+		if (IsElementNotPresent(locator1 = "ACSettings#EXIT_SETTINGS_BUTTON")) {
+			ACNavigation.goToSettings();
+		}
 
 		ACSettings.goToProperties();
 
-		Click(locator1 = "ACSettings#PROPERTIES_SEARCH_BAR");
+		Click(locator1 = "ACSettings#SEARCH_BAR");
 
 		Type(
-			locator1 = "ACSettings#PROPERTIES_SEARCH_BAR",
+			locator1 = "ACSettings#SEARCH_BAR",
 			value1 = "${propertyName}");
 
 		KeyPress(
-			locator1 = "ACSettings#PROPERTIES_SEARCH_BAR",
+			locator1 = "ACSettings#SEARCH_BAR",
 			value1 = "\ENTER");
 
-		Click(locator1 = "ACSettings#PROPERTIES_ITEM_ON_LIST");
+		Click(locator1 = "ACSettings#ITEM_ON_LIST");
 
 		Click(locator1 = "ACSettings#GENERIC_DELETE_BUTTON");
 
@@ -107,7 +111,7 @@ definition {
 
 		Paste(locator1 = "ACSettings#DELETE_CONFIRMATION_INPUT");
 
-		Click(locator1 = "ACSettings#GENERIC_CONFIRMATION_BUTTON");
+		Click(locator1 = "ACSettings#DELETE_CONFIRMATION_BUTTON");
 	}
 
 	macro goToApis {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACSettings.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACSettings.macro
@@ -36,6 +36,16 @@ definition {
 		}
 	}
 
+	macro deleteAllProperties {
+		if (!(isSet(propertyList))) {
+			var propertyList = "Liferay DXP,Liferay DXP Combined Property";
+		}
+
+		for(var itemName : list "${propertyList}"){
+			ACSettings.deleteProperty(propertyName = "${itemName}");
+		}
+	}
+
 	@summary = "Deletes a specific property \
 	@param propertyName the name of the property you want to delete"
 	macro deleteProperty {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACUtils.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACUtils.macro
@@ -132,4 +132,10 @@ definition {
 		ACSettings.deleteDataSource(dataSourceName = "Liferay DXP");
 	}
 
+	macro tearDownDXP {
+		ACUtils.launchDXP();
+
+		ACDXPSettings.disconnectDXPFromAnalyticsCloud();
+	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACUtils.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACUtils.macro
@@ -124,4 +124,12 @@ definition {
 		}
 	}
 
+	macro tearDownAC {
+		ACUtils.launchAC();
+
+		ACSettings.deleteAllProperties();
+
+		ACSettings.deleteDataSource(dataSourceName = "Liferay DXP");
+	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/paths/analyticscloud/ACSegments.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/analyticscloud/ACSegments.path
@@ -230,6 +230,16 @@
     <td>//h4[@class='no-results-title']</td>
     <td></td>
 </tr>
+<tr>
+    <td>FORM_CONTROL_CRITERION</td>
+    <td>//div[contains(@class,'form-group-item')and text()='${key_Criterion}']/..//select[contains(@class,'form-control')]</td>
+    <td></td>
+</tr>
+<tr>
+    <td>FORM_CONTROL_CRITERION_OPTION</td>
+    <td>//div[contains(@class,'form-group-item')and text()='${key_Criterion}']/..//select[contains(@class,'form-control')]//option[text()='${key_option}']</td>
+    <td></td>
+</tr>
 <!-- Static Segments  -->
 <tr>
     <td>ADD_BUTTON</td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/analyticscloud/ACSegments.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/analyticscloud/ACSegments.path
@@ -16,7 +16,7 @@
 </tr>
 <tr>
     <td>ANONYMOUS_LABEL</td>
-    <td>//div[@class='card-header']/div/span[@class='label-item']</td>
+    <td>//div[@class='card-header']/div/span[@class='label-item' and text()='Include Anonymous']</td>
     <td></td>
 </tr>
 <tr>
@@ -238,6 +238,11 @@
 <tr>
     <td>FORM_CONTROL_CRITERION_OPTION</td>
     <td>//div[contains(@class,'form-group-item')and text()='${key_Criterion}']/..//select[contains(@class,'form-control')]//option[text()='${key_option}']</td>
+    <td></td>
+</tr>
+<tr>
+    <td>SEGMENT_MEMBERSHIP_LEGEND</td>
+    <td>//span[contains(@class,'recharts-legend-item-text')]//span[text()='${key_memberType}']//b</td>
     <td></td>
 </tr>
 <!-- Static Segments  -->

--- a/portal-web/test/functional/com/liferay/portalweb/paths/analyticscloud/ACSettings.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/analyticscloud/ACSettings.path
@@ -74,13 +74,13 @@
 </tr>
 <!-- PROPERTIES -->
 <tr>
-    <td>PROPERTIES_SEARCH_BAR</td>
+    <td>SEARCH_BAR</td>
     <td>//div[@class='input-group-item']/input</td>
     <td></td>
 </tr>
 <tr>
-    <td>PROPERTIES_ITEM_ON_LIST</td>
-    <td>//span[contains(@class,'text-truncate') and contains(text(),'${propertyName}')]</td>
+    <td>ITEM_ON_LIST</td>
+    <td>//*[contains(@class,'text-truncate') and contains(text(),'${itemName}')]</td>
     <td></td>
 </tr>
 <tr>
@@ -99,8 +99,13 @@
     <td></td>
 </tr>
 <tr>
-    <td>GENERIC_CONFIRMATION_BUTTON</td>
-    <td>//input[@data-testid='delete-confirmation-input']</td>
+    <td>DELETE_CONFIRMATION_BUTTON</td>
+    <td>//button[contains(@class,'btn-warning')]</td>
+    <td></td>
+</tr>
+<tr>
+    <td>EXIT_SETTINGS_BUTTON</td>
+    <td>//a[@class='back-arrow']</td>
     <td></td>
 </tr>
 </tbody>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/AnalyticsCloudConnectionTest.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/AnalyticsCloudConnectionTest.testcase
@@ -34,13 +34,13 @@ definition {
 	tearDown {
 		var testPortalInstance = PropsUtil.get("test.portal.instance");
 
-		Navigator.openURL();
-
-		ACDXPSettings.disconnectDXPFromAnalyticsCloud();
+		ACUtils.tearDownDXP();
 
 		if ("${testPortalInstance}" == "true") {
 			PortalInstances.tearDownCP();
 		}
+
+		ACUtils.tearDownAC();
 	}
 
 	@description = "Validate if the user can connect AC to DXP"

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/AnalyticsCloudDXP.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/AnalyticsCloudDXP.testcase
@@ -19,10 +19,6 @@ definition {
 	tearDown {
 		var testPortalInstance = PropsUtil.get("test.portal.instance");
 
-		Navigator.openURL();
-
-		ACDXPSettings.disconnectDXPFromAnalyticsCloud();
-
 		if ("${testPortalInstance}" == "true") {
 			PortalInstances.tearDownCP();
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/AssertBlogs.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/AssertBlogs.testcase
@@ -24,9 +24,7 @@ definition {
 	tearDown {
 		var testPortalInstance = PropsUtil.get("test.portal.instance");
 
-		ACUtils.launchDXP();
-
-		ACDXPSettings.disconnectDXPFromAnalyticsCloud();
+		ACUtils.tearDownDXP();
 
 		if ("${testPortalInstance}" == "true") {
 			PortalInstances.tearDownCP();
@@ -34,6 +32,8 @@ definition {
 		else {
 			JSONGroup.deleteGroupByName(groupName = "Site Name");
 		}
+
+		ACUtils.tearDownAC();
 	}
 
 	@description = "Blogs visitor behavior card shows expected amount of views"

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/AssertDocumentsAndMedia.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/AssertDocumentsAndMedia.testcase
@@ -24,9 +24,7 @@ definition {
 	tearDown {
 		var testPortalInstance = PropsUtil.get("test.portal.instance");
 
-		ACUtils.launchDXP();
-
-		ACDXPSettings.disconnectDXPFromAnalyticsCloud();
+		ACUtils.tearDownDXP();
 
 		if ("${testPortalInstance}" == "true") {
 			PortalInstances.tearDownCP();
@@ -34,6 +32,8 @@ definition {
 		else {
 			JSONGroup.deleteGroupByName(groupName = "Site Name");
 		}
+
+		ACUtils.tearDownAC();
 	}
 
 	@description = "Documents visitor behavior card shows expected amount of views"

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/AssertWebContent.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/AssertWebContent.testcase
@@ -24,9 +24,7 @@ definition {
 	tearDown {
 		var testPortalInstance = PropsUtil.get("test.portal.instance");
 
-		ACUtils.launchDXP();
-
-		ACDXPSettings.disconnectDXPFromAnalyticsCloud();
+		ACUtils.tearDownDXP();
 
 		if ("${testPortalInstance}" == "true") {
 			PortalInstances.tearDownCP();
@@ -34,6 +32,8 @@ definition {
 		else {
 			JSONGroup.deleteGroupByName(groupName = "Site Name");
 		}
+
+		ACUtils.tearDownAC();
 	}
 
 	@description = "Web content visitor behavior card shows expected amount of views"

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/AssetsForms.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/AssetsForms.testcase
@@ -24,9 +24,7 @@ definition {
 	tearDown {
 		var testPortalInstance = PropsUtil.get("test.portal.instance");
 
-		ACUtils.launchDXP();
-
-		ACDXPSettings.disconnectDXPFromAnalyticsCloud();
+		ACUtils.tearDownDXP();
 
 		if ("${testPortalInstance}" == "true") {
 			PortalInstances.tearDownCP();
@@ -34,6 +32,8 @@ definition {
 		else {
 			JSONGroup.deleteGroupByName(groupName = "Site Name");
 		}
+
+		ACUtils.tearDownAC();
 	}
 
 	@description = "Form known individuals shows which individuals interact with the form"

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SegmentsCreation.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SegmentsCreation.testcase
@@ -28,8 +28,7 @@ definition {
 			PortalInstances.tearDownCP();
 		}
 
-		// TO DO: ACtearDown
-
+		ACUtils.tearDownAC();
 	}
 
 	@description = "Create a dynamic segment with individuals"
@@ -116,6 +115,63 @@ definition {
 		AssertElementPresent(
 			key_userName = "Test Test",
 			locator1 = "ACSegments#SEGMENT_MEMBERS");
+	}
+
+	@description = "Create a segment that contains anonymous individuals"
+	@priority = "5"
+	test CanCreateSegmentWithAnonymousIndividuals {
+		ACDXPSettings.connectDXPtoAnalyticsCloud();
+
+		Navigator.openURL();
+
+		Pause(locator1 = "5000");
+
+		JSONUser.addUser(
+			userEmailAddress = "ac@liferay.com",
+			userFirstName = "ac",
+			userLastName = "ac",
+			userScreenName = "ac");
+
+		User.logoutAndLoginPG(
+			userLoginEmailAddress = "ac@liferay.com",
+			userLoginFullName = "ac ac");
+
+		Navigator.openURL();
+
+		Pause(locator1 = "5000");
+
+		ACUtils.launchAC();
+
+		ACProperties.switchProperty(propertyName = "Liferay DXP Combined Property");
+
+		ACNavigation.goToSegments();
+
+		ACSegments.createDynamicSegment();
+
+		ACSegments.nameSegment(segmentName = "Dynamic Segment Test");
+
+		ACSegments.includeAnonymous();
+
+		ACSegments.goToSidebarAttrributes(criterion = "Individual Attributes");
+
+		ACSegments.addSegmentField(segmentField = "fullName");
+
+		ACSegments.editFormControlCriterion(
+			criterionName = "fullName",
+			option = "is unknown");
+
+		ACSegments.saveSegment();
+
+		ACNavigation.goToSegments();
+
+		ACSegments.accessSegment(segmentName = "Dynamic Segment Test");
+
+		ACSegments.viewSegmentMembershipLegendNumbers(
+			knownNumber = "1",
+			anonymousNumber = "1",
+			totalNumber = "2");
+
+		ACSegments.viewIncludeAnonymousLabel();
 	}
 
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SegmentsCreation.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SegmentsCreation.testcase
@@ -74,4 +74,48 @@ definition {
 			locator1 = "ACSegments#SEGMENT_MEMBERS");
 	}
 
+	@description = "Create a Dynamic Individuals Segment with a criteria that uses is unknown"
+	@priority = "5"
+	test CanCreateDynamicSegmentWithIndividualsUseUnknown {
+		ACDXPSettings.connectDXPtoAnalyticsCloud();
+
+		Navigator.openURL();
+
+		Pause(locator1 = "5000");
+
+		ACUtils.launchAC();
+
+		ACProperties.switchProperty(propertyName = "Liferay DXP Combined Property");
+
+		ACNavigation.goToSegments();
+
+		ACSegments.createDynamicSegment();
+
+		ACSegments.nameSegment(segmentName = "Dynamic Segment Test");
+
+		ACSegments.goToSidebarAttrributes(criterion = "Individual Attributes");
+
+		ACSegments.addSegmentField(segmentField = "fullName");
+
+		ACSegments.editFormControlCriterion(
+			criterionName = "fullName",
+			option = "is unknown");
+
+		ACSegments.saveSegment();
+
+		ACNavigation.goToSegments();
+
+		ACSegments.accessSegment(segmentName = "Dynamic Segment Test");
+
+		ACNavigation.switchTab(tabName = "Membership");
+
+		AssertTextEquals(
+			locator1 = "ACSegments#SEGMENT_LABEL",
+			value1 = "DYNAMIC SEGMENT");
+
+		AssertElementPresent(
+			key_userName = "Test Test",
+			locator1 = "ACSegments#SEGMENT_MEMBERS");
+	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SegmentsCreation.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SegmentsCreation.testcase
@@ -20,9 +20,7 @@ definition {
 	tearDown {
 		var testPortalInstance = PropsUtil.get("test.portal.instance");
 
-		ACUtils.launchDXP();
-
-		ACDXPSettings.disconnectDXPFromAnalyticsCloud();
+		ACUtils.tearDownDXP();
 
 		if ("${testPortalInstance}" == "true") {
 			PortalInstances.tearDownCP();

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SegmentsCreation.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SegmentsCreation.testcase
@@ -165,8 +165,8 @@ definition {
 		ACSegments.accessSegment(segmentName = "Dynamic Segment Test");
 
 		ACSegments.viewSegmentMembershipLegendNumbers(
-			knownNumber = "1",
 			anonymousNumber = "1",
+			knownNumber = "1",
 			totalNumber = "2");
 
 		ACSegments.viewIncludeAnonymousLabel();

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SegmentsCreationWebBehavior.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SegmentsCreationWebBehavior.testcase
@@ -22,9 +22,7 @@ definition {
 	tearDown {
 		var testPortalInstance = PropsUtil.get("test.portal.instance");
 
-		ACUtils.launchDXP();
-
-		ACDXPSettings.disconnectDXPFromAnalyticsCloud();
+		ACUtils.tearDownDXP();
 
 		if ("${testPortalInstance}" == "true") {
 			PortalInstances.tearDownCP();
@@ -32,6 +30,8 @@ definition {
 		else {
 			JSONGroup.deleteGroupByName(groupName = "Site Name");
 		}
+
+		ACUtils.tearDownAC();
 	}
 
 	@description = "Create a Web Behavior Segment Submitting a Form"


### PR DESCRIPTION
New test cases: 
* CanCreateDynamicSegmentWithIndividualsUseUnknown
* CanCreateSegmentWithAnonymousIndividuals testcase

Macros and tests refactored:
* ACSettings.deleteProperty();
* Updated the test case teardowns to use tearDownAC() and tearDownDXP();

New macros:
* ACSettings.deleteAllProperties();
* ACSettings.deleteDataSource();
* ACUtils.tearDownAC();
* ACUtils.tearDownDXP();

